### PR TITLE
fixed bug in adding and removing state assignments and output events

### DIFF
--- a/nineml/abstraction_layer/dynamics/transitions.py
+++ b/nineml/abstraction_layer/dynamics/transitions.py
@@ -264,18 +264,20 @@ class Transition(BaseALObject, MemberContainerObject):
             self._state_assignments[element.name] = element
         elif isinstance(element, OutputEvent):
             self._output_events[element.name] = element
-        raise NineMLInvalidElementTypeException(
-            "Could not add element of type '{}' to {} class"
-            .format(element.__class__.__name__, self.__class__.__name__))
+        else:
+            raise NineMLInvalidElementTypeException(
+                "Could not add element of type '{}' to {} class"
+                .format(element.__class__.__name__, self.__class__.__name__))
 
     def remove(self, element):
         if isinstance(element, StateAssignment):
             self._state_assignments.pop(element.name)
         elif isinstance(element, OutputEvent):
             self._output_events.pop(element.name)
-        raise NineMLInvalidElementTypeException(
-            "Could not remove element of type '{}' to {} class"
-            .format(element.__class__.__name__, self.__class__.__name__))
+        else:
+            raise NineMLInvalidElementTypeException(
+                "Could not remove element of type '{}' to {} class"
+                .format(element.__class__.__name__, self.__class__.__name__))
 
 
 class OnEvent(Transition):

--- a/test/unit/nineml_test/abstraction_layer/modifiers/member_container_test.py
+++ b/test/unit/nineml_test/abstraction_layer/modifiers/member_container_test.py
@@ -41,7 +41,9 @@ class MemberContainer_test(unittest.TestCase):
                     'dSV2/dt = SV1 / (ARP1*t) + SV2 / (P1*t)',
                     'dSV3/dt = -SV3/t + P3/t',
                     transitions=[On('SV1 > P1', do=[OutputEvent('emit')]),
-                                 On('spikein', do=[OutputEvent('emit')])],
+                                 On('spikein', do=[
+                                    OutputEvent('emit'),
+                                    StateAssignment('SV1', 'P1')])],
                     name='R1',
                 ),
                 Regime(name='R2', transitions=[
@@ -65,6 +67,7 @@ class MemberContainer_test(unittest.TestCase):
         a.add(Alias('A4', 'SV1^3 + SV2^-3'))
         a.add(StateVariable('SV3'))
         a.regime('R1').add(TimeDerivative('SV3', '-SV3/t + P3/t'))
+        a.regime('R1').on_event('spikein').add(StateAssignment('SV1', 'P1'))
         a.regime('R2').add(OnCondition(
             'SV3 < 0.001', target_regime='R2',
             state_assignments=[StateAssignment('SV3', 1)]))
@@ -83,6 +86,8 @@ class MemberContainer_test(unittest.TestCase):
         b.remove(b.alias('A4'))
         b.remove(b.state_variable('SV3'))
         b.regime('R1').remove(b.regime('R1').time_derivative('SV3'))
+        b.regime('R1').on_event('spikein').remove(
+            b.regime('R1').on_event('spikein').state_assignment('SV1'))
         b.regime('R2').remove(b.regime('R2').on_condition('SV3 < 0.001'))
         b.remove(b.analog_send_port('SV3'))
         b.remove(b.parameter('P3'))


### PR DESCRIPTION
fixed bug in adding and removing state assignments and output events from transitions where an exception wasn't within an else statement and was therefore always raised
