### PR TITLE
renamed `standardLibrary` XML attribute to `standard_library` 

### DIFF
--- a/examples/_old/Brunel2000/AllToAll.xml
+++ b/examples/_old/Brunel2000/AllToAll.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
-    <ConnectionRule standardLibrary="AllToAll" />
+    <ConnectionRule standard_library="AllToAll" />
   </ComponentClass>
 </NineML>

--- a/examples/_old/Brunel2000/OneToOne.xml
+++ b/examples/_old/Brunel2000/OneToOne.xml
@@ -1,5 +1,5 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="OneToOne">
-    <ConnectionRule standardLibrary="OneToOne" />
+    <ConnectionRule standard_library="OneToOne" />
   </ComponentClass>
 </NineML>

--- a/examples/_old/Brunel2000/RandomFanIn.xml
+++ b/examples/_old/Brunel2000/RandomFanIn.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="RandomFanIn">
     <Parameter name="number"/>
-    <ConnectionRule standardLibrary="RandomFanIn" />
+    <ConnectionRule standard_library="RandomFanIn" />
   </ComponentClass>
 </NineML>

--- a/nineml/abstraction/connectionrule/utils/xml.py
+++ b/nineml/abstraction/connectionrule/utils/xml.py
@@ -40,7 +40,7 @@ class ConnectionRuleXMLLoader(ComponentClassXMLLoader):
         subblocks = ()
         children = self._load_blocks(element, blocks=subblocks)  # @UnusedVariable @IgnorePep8
         return ConnectionRuleBlock(
-            standard_library=element.attrib['standardLibrary'])
+            standard_library=element.attrib['standard_library'])
 
     tag_to_loader = {
         "ComponentClass": load_componentclass,
@@ -60,6 +60,6 @@ class ConnectionRuleXMLWriter(ComponentClassXMLWriter):
     @annotate_xml
     def visit_connectionruleblock(self, connectionrule):
         return E('ConnectionRule',
-                 standardLibrary=connectionrule.standard_library)
+                 standard_library=connectionrule.standard_library)
 
 from ..base import ConnectionRule, ConnectionRuleBlock

--- a/nineml/abstraction/randomdistribution/utils/xml.py
+++ b/nineml/abstraction/randomdistribution/utils/xml.py
@@ -42,7 +42,7 @@ class RandomDistributionXMLLoader(ComponentClassXMLLoader):
         subblocks = ()
         children = self._load_blocks(element, blocks=subblocks)  # @UnusedVariable @IgnorePep8
         return RandomDistributionBlock(
-            standard_library=element.attrib['standardLibrary'])
+            standard_library=element.attrib['standard_library'])
 
     tag_to_loader = {
         "ComponentClass": load_componentclass,
@@ -62,4 +62,4 @@ class RandomDistributionXMLWriter(ComponentClassXMLWriter):
     @annotate_xml
     def visit_randomdistributionblock(self, randomdistributionblock):
         return E('RandomDistribution',
-                 standardLibrary=randomdistributionblock.standard_library)
+                 standard_library=randomdistributionblock.standard_library)

--- a/nineml/user/component.py
+++ b/nineml/user/component.py
@@ -130,10 +130,14 @@ class Component(BaseULObject, DocumentLevelObject):
         DocumentLevelObject.__init__(self, url)
         self.name = name
         if isinstance(definition, basestring):
+            if "#" in definition:
+                defn_url, name = definition.split("#")
+            else:
+                defn_url, name = definition, path.basename(definition).replace(".xml", "")
             definition = Definition(
-                name=path.basename(definition).replace(".xml", ""),
+                name=name,
                 document=Document(url=url),
-                url=definition)
+                url=defn_url)
         elif isinstance(definition, ComponentClass):
             definition = Definition(component_class=definition)
         elif isinstance(definition, Component):

--- a/test/unit/data/xml/connectionrules/AllToAll.xml
+++ b/test/unit/data/xml/connectionrules/AllToAll.xml
@@ -1,5 +1,5 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/connectionrules/ExplicitConnectionList.xml
+++ b/test/unit/data/xml/connectionrules/ExplicitConnectionList.xml
@@ -2,7 +2,7 @@
   <ComponentClass name="ExplicitConnectionList">
     <Parameter name="sourceIndices" dimension="dimensionless"/>
     <Parameter name="destinationIndices" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/ExplicitConnectionList"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/ExplicitConnectionList"/>
   </ComponentClass>
   <Dimension name="dimensionless"/>
 </NineML>

--- a/test/unit/data/xml/connectionrules/OneToOne.xml
+++ b/test/unit/data/xml/connectionrules/OneToOne.xml
@@ -1,5 +1,5 @@
 <NineML xmlns="http://nineml.org/9ML/0.1">
   <ComponentClass name="OneToOne">
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/OneToOne"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/OneToOne"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/connectionrules/ProbabilisticConnectivity.xml
+++ b/test/unit/data/xml/connectionrules/ProbabilisticConnectivity.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/connectionrules/RandomFanIn.xml
+++ b/test/unit/data/xml/connectionrules/RandomFanIn.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/connectionrules/RandomFanOut.xml
+++ b/test/unit/data/xml/connectionrules/RandomFanOut.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Bernoulli.xml
+++ b/test/unit/data/xml/randomdistributions/Bernoulli.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="BernoulliDistribution">
     <Parameter name="probabilities"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/bernoulli.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/bernoulli.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Beta.xml
+++ b/test/unit/data/xml/randomdistributions/Beta.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="BetaDistribution">
     <Parameter name="alpha"/>
     <Parameter name="beta"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/beta.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/beta.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Binomial.xml
+++ b/test/unit/data/xml/randomdistributions/Binomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="BinomialDistribution">
     <Parameter name="numberOfTrials"/>
     <Parameter name="probabilityOfSuccess"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/binomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/binomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Cauchy.xml
+++ b/test/unit/data/xml/randomdistributions/Cauchy.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="CauchyDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/cauchy.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/cauchy.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/ChiSquare.xml
+++ b/test/unit/data/xml/randomdistributions/ChiSquare.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="ChiSquareDistribution">
     <Parameter name="degreesOfFreedom"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/chi-square.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/chi-square.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Dirichlet.xml
+++ b/test/unit/data/xml/randomdistributions/Dirichlet.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="DirichletDistribution">
     <Parameter name="concentration"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/dirichlet.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/dirichlet.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Exponential.xml
+++ b/test/unit/data/xml/randomdistributions/Exponential.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="ExponentialDistribution">
     <Parameter name="rate"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/exponential.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/exponential.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Geometric.xml
+++ b/test/unit/data/xml/randomdistributions/Geometric.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="GeometricDistribution">
     <Parameter name="probability"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/geometric.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/geometric.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Hypergeometric.xml
+++ b/test/unit/data/xml/randomdistributions/Hypergeometric.xml
@@ -4,6 +4,6 @@
     <Parameter name="numberOfSuccesses"/>
     <Parameter name="numberOfTrials"/>
     <Parameter name="populationSize"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/hypergeometric.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/hypergeometric.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Laplace.xml
+++ b/test/unit/data/xml/randomdistributions/Laplace.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LaplaceDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/laplace.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/laplace.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Log-normal.xml
+++ b/test/unit/data/xml/randomdistributions/Log-normal.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LogNormalDistribution">
     <Parameter name="logScale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/log-normal.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/log-normal.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Logistic.xml
+++ b/test/unit/data/xml/randomdistributions/Logistic.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LogisticDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/logistic.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/logistic.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Multinomial.xml
+++ b/test/unit/data/xml/randomdistributions/Multinomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="MultinomialDistribution">
     <Parameter name="numberOfTrials"/>
     <Parameter name="probabilities"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/multinomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/multinomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/NegativeBinomial.xml
+++ b/test/unit/data/xml/randomdistributions/NegativeBinomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="NegativeBinomialDistribution">
     <Parameter name="numberOfFailures"/>
     <Parameter name="probability"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/negative-binomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/negative-binomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Normal.xml
+++ b/test/unit/data/xml/randomdistributions/Normal.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="NormalDistribution">
     <Parameter name="mean"/>
     <Parameter name="variance"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/normal.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/normal.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/NormalInverseGamma.xml
+++ b/test/unit/data/xml/randomdistributions/NormalInverseGamma.xml
@@ -5,6 +5,6 @@
     <Parameter name="varianceScaling"/>
     <Parameter name="shape"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/normal-inverse-gamma.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/normal-inverse-gamma.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Pareto.xml
+++ b/test/unit/data/xml/randomdistributions/Pareto.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="ParetoDistribution">
     <Parameter name="scale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/pareto.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/pareto.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Poisson.xml
+++ b/test/unit/data/xml/randomdistributions/Poisson.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="PoissonDistribution">
     <Parameter name="rate"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/poisson.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/poisson.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/StudentT.xml
+++ b/test/unit/data/xml/randomdistributions/StudentT.xml
@@ -4,6 +4,6 @@
     <Parameter name="location"/>
     <Parameter name="scale"/>
     <Parameter name="degreesOfFreedom"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/student-t.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/student-t.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Uniform.xml
+++ b/test/unit/data/xml/randomdistributions/Uniform.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="UniformDistribution">
     <Parameter name="minimum"/>
     <Parameter name="maximum"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/uniform.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/uniform.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Weibull.xml
+++ b/test/unit/data/xml/randomdistributions/Weibull.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="WeibullDistribution">
     <Parameter name="scale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/weibull.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/weibull.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/unit/data/xml/randomdistributions/Wishart.xml
+++ b/test/unit/data/xml/randomdistributions/Wishart.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="WishartDistribution">
     <Parameter name="degreesOfFreedom"/>
     <Parameter name="scaleMatrix"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/wishart.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/wishart.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/connectionrules/AllToAll.xml
+++ b/test/xml/connectionrules/AllToAll.xml
@@ -1,5 +1,5 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/connectionrules/ExplicitConnectionList.xml
+++ b/test/xml/connectionrules/ExplicitConnectionList.xml
@@ -2,7 +2,7 @@
   <ComponentClass name="ExplicitConnectionList">
     <Parameter name="sourceIndices" dimension="dimensionless"/>
     <Parameter name="destinationIndices" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/ExplicitConnectionList"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/ExplicitConnectionList"/>
   </ComponentClass>
   <Dimension name="dimensionless"/>
 </NineML>

--- a/test/xml/connectionrules/OneToOne.xml
+++ b/test/xml/connectionrules/OneToOne.xml
@@ -1,5 +1,5 @@
 <NineML xmlns="http://nineml.org/9ML/0.1">
   <ComponentClass name="OneToOne">
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/OneToOne"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/OneToOne"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/connectionrules/ProbabilisticConnectivity.xml
+++ b/test/xml/connectionrules/ProbabilisticConnectivity.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/connectionrules/RandomFanIn.xml
+++ b/test/xml/connectionrules/RandomFanIn.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/connectionrules/RandomFanOut.xml
+++ b/test/xml/connectionrules/RandomFanOut.xml
@@ -1,6 +1,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="AllToAll">
     <Parameter name="probability" dimension="dimensionless"/>
-    <ConnectionRule standardLibrary="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
+    <ConnectionRule standard_library="http://nineml.net/standardlibraries/connectionrules/AllToAll"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Bernoulli.xml
+++ b/test/xml/randomdistributions/Bernoulli.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="BernoulliDistribution">
     <Parameter name="probabilities"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/bernoulli.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/bernoulli.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Beta.xml
+++ b/test/xml/randomdistributions/Beta.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="BetaDistribution">
     <Parameter name="alpha"/>
     <Parameter name="beta"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/beta.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/beta.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Binomial.xml
+++ b/test/xml/randomdistributions/Binomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="BinomialDistribution">
     <Parameter name="numberOfTrials"/>
     <Parameter name="probabilityOfSuccess"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/binomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/binomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Cauchy.xml
+++ b/test/xml/randomdistributions/Cauchy.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="CauchyDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/cauchy.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/cauchy.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/ChiSquare.xml
+++ b/test/xml/randomdistributions/ChiSquare.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="ChiSquareDistribution">
     <Parameter name="degreesOfFreedom"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/chi-square.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/chi-square.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Dirichlet.xml
+++ b/test/xml/randomdistributions/Dirichlet.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="DirichletDistribution">
     <Parameter name="concentration"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/dirichlet.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/dirichlet.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Exponential.xml
+++ b/test/xml/randomdistributions/Exponential.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="ExponentialDistribution">
     <Parameter name="rate"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/exponential.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/exponential.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Geometric.xml
+++ b/test/xml/randomdistributions/Geometric.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="GeometricDistribution">
     <Parameter name="probability"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/geometric.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/geometric.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Hypergeometric.xml
+++ b/test/xml/randomdistributions/Hypergeometric.xml
@@ -4,6 +4,6 @@
     <Parameter name="numberOfSuccesses"/>
     <Parameter name="numberOfTrials"/>
     <Parameter name="populationSize"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/hypergeometric.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/hypergeometric.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Laplace.xml
+++ b/test/xml/randomdistributions/Laplace.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LaplaceDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/laplace.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/laplace.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Log-normal.xml
+++ b/test/xml/randomdistributions/Log-normal.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LogNormalDistribution">
     <Parameter name="logScale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/log-normal.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/log-normal.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Logistic.xml
+++ b/test/xml/randomdistributions/Logistic.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="LogisticDistribution">
     <Parameter name="location"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/logistic.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/logistic.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Multinomial.xml
+++ b/test/xml/randomdistributions/Multinomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="MultinomialDistribution">
     <Parameter name="numberOfTrials"/>
     <Parameter name="probabilities"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/multinomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/multinomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/NegativeBinomial.xml
+++ b/test/xml/randomdistributions/NegativeBinomial.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="NegativeBinomialDistribution">
     <Parameter name="numberOfFailures"/>
     <Parameter name="probability"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/negative-binomial.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/negative-binomial.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Normal.xml
+++ b/test/xml/randomdistributions/Normal.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="NormalDistribution">
     <Parameter name="mean"/>
     <Parameter name="variance"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/normal.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/normal.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/NormalInverseGamma.xml
+++ b/test/xml/randomdistributions/NormalInverseGamma.xml
@@ -5,6 +5,6 @@
     <Parameter name="varianceScaling"/>
     <Parameter name="shape"/>
     <Parameter name="scale"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/normal-inverse-gamma.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/normal-inverse-gamma.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Pareto.xml
+++ b/test/xml/randomdistributions/Pareto.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="ParetoDistribution">
     <Parameter name="scale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/pareto.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/pareto.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Poisson.xml
+++ b/test/xml/randomdistributions/Poisson.xml
@@ -2,6 +2,6 @@
 <NineML xmlns="http://nineml.net/9ML/1.0">
   <ComponentClass name="PoissonDistribution">
     <Parameter name="rate"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/poisson.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/poisson.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/StudentT.xml
+++ b/test/xml/randomdistributions/StudentT.xml
@@ -4,6 +4,6 @@
     <Parameter name="location"/>
     <Parameter name="scale"/>
     <Parameter name="degreesOfFreedom"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/student-t.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/student-t.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Uniform.xml
+++ b/test/xml/randomdistributions/Uniform.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="UniformDistribution">
     <Parameter name="minimum"/>
     <Parameter name="maximum"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/uniform.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/uniform.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Weibull.xml
+++ b/test/xml/randomdistributions/Weibull.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="WeibullDistribution">
     <Parameter name="scale"/>
     <Parameter name="shape"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/weibull.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/weibull.xml"/>
   </ComponentClass>
 </NineML>

--- a/test/xml/randomdistributions/Wishart.xml
+++ b/test/xml/randomdistributions/Wishart.xml
@@ -3,6 +3,6 @@
   <ComponentClass name="WishartDistribution">
     <Parameter name="degreesOfFreedom"/>
     <Parameter name="scaleMatrix"/>
-    <RandomDistribution standardLibrary="http://www.uncertml.org/distributions/wishart.xml"/>
+    <RandomDistribution standard_library="http://www.uncertml.org/distributions/wishart.xml"/>
   </ComponentClass>
 </NineML>


### PR DESCRIPTION
to match spec (cf https://github.com/INCF/NineMLCatalog/commit/e28a06d8f6da9c88073143ac30c2c41aa81822b4)
