### PR TITLE
Added hdf5 support as an install extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ addons:
     packages:
     - libhdf5-serial-dev 
 install:
-  - pip install .
-  - pip install coveralls
-  - pip install numpy
+  - pip install -e .[hdf5]
+  - pip install numpy coveralls
 script:
   nosetests test/unittests --with-coverage --cover-package=nineml
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,12 @@ community please consider contributing to the catalog via a pull request.
 Installation
 ------------
 
-HDF5 (dev)
-~~~~~~~~~~
+The NineML Python Library can be installed using *pip*::
+
+    $ pip install nineml
+
+HDF5 Support
+~~~~~~~~~~~~
 
 To add support to read or write HDF5_ serialisations you must first install
 a HDF5_ dev library (i.e. with the C headers). 
@@ -86,15 +90,9 @@ On Ubuntu/Debian HDF5_ can be installed by one of the following packages:
 * libhdf5-openmpi-dev (parallel with Open MPI)
 * libhdf5-mpich-dev (parallel with MPICH)
 
-If you don't install HDF5_ the other serialisation formats can still be used
-but you will need to install the package manually (i.e. not use *pip*).
+Then to install *pype9* with support for HDF5_ select the 'hdf5' extra::
 
-Pip
-~~~
-
-The NineML Python Library can be installed using *pip*::
-
-    $ pip install nineml
+    $ pip install nineml[hdf5]
 
 :copyright: Copyright 20011-2017 by the NineML Python Library team, see AUTHORS.
 :license: BSD 3, see LICENSE for details.

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,10 @@ setup(
                  'Topic :: Scientific/Engineering'],
     install_requires=['lxml>=3.7.3',
                       'future>=0.16.0',
-                      'h5py>=2.7.0',
                       'PyYAML>=3.1',
                       'sympy>=1.1'],
+    extras_require={
+        'hdf5': 'h5py>=2.7.0'},
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
     tests_require=['nose', 'numpy']
 )


### PR DESCRIPTION
Moved h5py from `install_requires` to `extras_require` in `setup.py ` to allow the package to be installed via pip when development HDF5 libraries are not available.