### PR TITLE
fixed handling of c89 '!' negation when using 'tokenize' package instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-        - python: 3.3
+        - python: 3.4
         - python: 3.6
 addons:
   apt:

--- a/nineml/abstraction/expressions/parser.py
+++ b/nineml/abstraction/expressions/parser.py
@@ -8,7 +8,7 @@ from itertools import chain
 import sympy
 from sympy.parsing.sympy_parser import (
     parse_expr as sympy_parse, standard_transformations, convert_xor)
-from sympy.parsing.sympy_tokenize import NAME, OP
+from tokenize import NAME, OP
 import operator
 import re
 from nineml.exceptions import NineMLMathParseError
@@ -118,14 +118,10 @@ class Parser(object):
                 # Unescape relationals escaped in _parse_relationals
                 elif tokval.endswith('__'):
                     tokval = tokval[:-2]
-            # Handle multiple negations
-            elif toknum == OP and tokval.startswith('!'):
-                # NB: Multiple !'s are grouped into the one token
-                assert all(t == '!' for t in tokval)
-                if len(tokval) % 2:
-                    tokval = '~'  # odd number of negation symbols
-                else:
-                    continue  # even number of negation symbols, cancel out
+            # Handle C89 negations
+            elif tokval == '!':
+                toknum = OP
+                tokval = '~'
             result.append((toknum, tokval))
         new_result = []
         # Loop through pairwise combinations

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
                  'Programming Language :: Python :: 2',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3',
-                 'Programming Language :: Python :: 3.3',
                  'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
                       'future>=0.16.0',
                       'h5py>=2.7.0',
                       'PyYAML>=3.1',
-                      'sympy>=1.1'],
+                      'sympy>=1.2'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
     tests_require=['nose', 'numpy']
 )


### PR DESCRIPTION
Sympy's switch to using the builtin package 'tokenize' from their internal package (versions >=1.2), broke the ad-hoc handling of C89 negations (i.e. '!'). This PR changes the import of the tokenize package as suggested by @sanjayankur31 in #40 and the handling of '!'